### PR TITLE
Add setting to hide welcome text on login page

### DIFF
--- a/ganetimgr/settings-test.py
+++ b/ganetimgr/settings-test.py
@@ -131,6 +131,7 @@ BRANDING = {
     "FAVICON": "/static/ganetimgr/img/favicon.ico",
     "MOTTO": "virtual private servers",
     "FOOTER_ICONS_IFRAME": True,
+    "SHOW_WELCOME_TEXT": True,
     # show the administrative contact
     # option when creating a new vm
     "SHOW_ADMINISTRATIVE_FORM": True,

--- a/ganetimgr/settings.py.dist
+++ b/ganetimgr/settings.py.dist
@@ -251,6 +251,7 @@ BRANDING = {
     "FAVICON": "/static/ganetimgr/img/favicon.ico",
     "MOTTO": "virtual private servers",
     "FOOTER_ICONS_IFRAME": False,
+    "SHOW_WELCOME_TEXT": True,
     # show the administrative contact
     # option when creating a new vm
     "SHOW_ADMINISTRATIVE_FORM": True,

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -82,6 +82,7 @@
 						</div>
 					{% endif %}
 						<div class="{% if BRANDING.FEED_URL %}span3{% else %}span4{% endif %} sidebar">
+						{% if BRANDING.SHOW_WELCOME_TEXT %}
 							<div class="widget">
 								<div class="row-fluid">
 									<h2><i class="fa fa-cloud"></i> {% trans "Welcome" %}</h2>
@@ -112,6 +113,7 @@
 									</div>
 								</div>
 							</div>
+						{% endif %}
 						</div>
 						<div class="{% if BRANDING.FEED_URL %}span3{% else %}span4{% endif %} sidebar">
 							<div class="widget">


### PR DESCRIPTION
When e.g. used internally a welcome text is not always desirable, this PR makes it optional with a setting.